### PR TITLE
Fixed crash on Windows and Qt 5.5 on startup

### DIFF
--- a/src/core/xmltv/XmltvCommon.h
+++ b/src/core/xmltv/XmltvCommon.h
@@ -23,6 +23,7 @@
 #include <QtCore/QStringList>
 
 #include "CoreSharedExport.h"
+#include <QtCore/QMap>
 
 namespace Tano
 {

--- a/src/core/xmltv/XmltvCommonCategories.cpp
+++ b/src/core/xmltv/XmltvCommonCategories.cpp
@@ -19,6 +19,7 @@
 #include <QtCore/QMap>
 
 #include "XmltvCommon.h"
+#include <QtCore/QObject>
 
 QMap<QString, QString> Tano::Xmltv::categoryMap()
 {

--- a/src/widgets/MainWindow.cpp
+++ b/src/widgets/MainWindow.cpp
@@ -253,11 +253,12 @@ void MainWindow::changeEvent(QEvent *e)
     switch (e->type()) {
         case QEvent::LanguageChange:
             ui->retranslateUi(this);
-
-            ui->tabs->renameTab(0, tr("Channels"));
-            ui->tabs->renameTab(1, tr("Schedule"));
-            ui->tabs->renameTab(2, tr("Show Info"));
-            ui->tabs->renameTab(3, tr("Recorder"));
+            if (ui->tabs->tabCount()) {
+                ui->tabs->renameTab(0, tr("Channels"));
+                ui->tabs->renameTab(1, tr("Schedule"));
+                ui->tabs->renameTab(2, tr("Show Info"));
+                ui->tabs->renameTab(3, tr("Recorder"));
+            }
             break;
         default:
             break;

--- a/src/widgets/style/FancyTabWidget.cpp
+++ b/src/widgets/style/FancyTabWidget.cpp
@@ -484,6 +484,10 @@ void FancyTabWidget::paintEvent(QPaintEvent *event)
     }
 }
 
+int FancyTabWidget::tabCount() const {
+    return _tabBar->count();
+}
+
 void FancyTabWidget::insertCornerWidget(int pos,
                                         QWidget *widget)
 {

--- a/src/widgets/style/FancyTabWidget.h
+++ b/src/widgets/style/FancyTabWidget.h
@@ -155,6 +155,7 @@ public:
 
     void paintEvent(QPaintEvent *event);
 
+    int tabCount() const;
     int currentIndex() const;
     QWidget *currentWidget() const;
     QStatusBar *statusBar() const;


### PR DESCRIPTION
Msvc 2013
Also fixed compilation error due to missing includes

```
+       msg ASSERT failure in QList<T>::at: "index out of range", file C:\Qt\Qt5.5\5.5\msvc2013\include\QtCore/qlist.h, line 510    const QString &
>   tanocore.dll!Tano::Log::output(QtMsgType type, const QMessageLogContext & context, const QString & msg) Line 69 C++
    Qt5Cored.dll!66156cf6() Unknown
    Qt5Cored.dll!661570e8() Unknown
    Qt5Cored.dll!661558ec() Unknown
    Qt5Cored.dll!6614c708() Unknown
    tanowidgets.dll!QList<FancyTab *>::at(int i) Line 510   C++
    tanowidgets.dll!FancyTabBar::setTabText(int index, const QString & text) Line 113   C++
    tanowidgets.dll!FancyTabWidget::renameTab(int index, const QString & name) Line 457 C++
    tanowidgets.dll!MainWindow::changeEvent(QEvent * e) Line 257    C++
```
